### PR TITLE
chore:  Change evcc configuration for 15-minute prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,6 @@ tariffs:
     forecast:
       source: http
       uri: https://epexpredictor.batzill.com/prices?country=DE&fixedPrice=13.15&taxPercent=19&unit=EUR_PER_KWH&timezone=UTC
-      jq: '[.prices[] | { start: .startsAt, "end": (.startsAt | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "value": .total}] | tostring'
+      jq: '[.prices[] | { start: .startsAt, "end": (.startsAt | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime + 900 | strftime("%Y-%m-%dT%H:%M:%SZ")), "value": .total}] | tostring'
 ```
 


### PR DESCRIPTION
Fix end time is calculation for 15-minute prices  in evcc configuration.