### PR TITLE
fix: request energy-charts prices on local day boundaries

### DIFF
--- a/predictor/model/pricestore.py
+++ b/predictor/model/pricestore.py
@@ -128,8 +128,11 @@ class PriceStore(DataStore):
     async def fetch_prices_energycharts(self, rstart: datetime, rend: datetime) -> pd.DataFrame | None:
         try:
             if self.region.bidding_zone_energycharts is not None:
-                start_of_day = rstart.replace(hour=0, minute=0, second=0, microsecond=0)
-                end_of_day = rend.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+                # The market day runs on local time. Snapping to UTC midnight cuts the
+                # first hours of the day off the request for any zone east of UTC.
+                tzlocal = self.region.get_timezone_info()
+                start_of_day = rstart.astimezone(tzlocal).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(timezone.utc)
+                end_of_day = (rend.astimezone(tzlocal).replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)).astimezone(timezone.utc)
                 start_formatted = start_of_day.isoformat().replace("+00:00", "Z")
                 end_formatted = end_of_day.isoformat().replace("+00:00", "Z")
                 url = f"https://api.energy-charts.info/price?bzn={self.region.bidding_zone_energycharts}&start={start_formatted}&end={end_formatted}"


### PR DESCRIPTION
Rebased onto current master.

## Problem

`fetch_prices_energycharts` snaps the requested range to UTC midnight:

```python
start_of_day = rstart.replace(hour=0, minute=0, second=0, microsecond=0)
```

`rstart` is already UTC here, but the market day runs on local time. For a
bidding zone east of UTC this drops the first hours of the day from the request,
and energy-charts returns exactly the window it was asked for.

Reproducible for BE (CEST, UTC+2):

```
start=2026-07-24T00:00:00Z  ->  88 quarter hours, first one 02:00 local
start=2026-07-23T00:00:00Z  -> 184 quarter hours, includes 00:00 local
```

The eight quarter hours from 00:00 to 01:45 local were never fetched. They ended
up in the store as 0.0 and were served by `/prices` as real prices:

```
2026-07-23T23:45:00+02:00   162.40
2026-07-24T00:00:00+02:00     0.00
   ...
2026-07-24T01:45:00+02:00     0.00
2026-07-24T02:00:00+02:00   155.26
```

That is the cheapest slot of the whole horizon, so anything optimising on price
schedules load exactly there while the real price was around 155 EUR/MWh.

This usually repairs itself, because a later and wider fetch covers the same
range before those hours become the present. It only surfaces when the fetched
range starts on the new UTC day. The gap is the size of the UTC offset: two
hours in CEST, one hour in CET.

## Relation to #30 / `_is_invalid_zero_data`

This is the same family of problem as #30 (and the zero data mentioned in #34),
but the guard added there only discards a fetch when the last ~20 hours are all
zero, i.e. a full-day blackout. The case here is a partial gap of a few quarter
hours at the day boundary, embedded in otherwise valid data, so the guard does
not catch it. That guard treats the symptom; this change removes the cause, so
those quarter hours are fetched with real prices in the first place. The two are
independent and both useful.

## Fix

Convert the range to the bidding zone timezone before snapping to midnight, then
back to UTC for the query. `region.get_timezone_info()` is already used
elsewhere in this class. The window can only grow, so nothing that was covered
before stops being covered.

Observed on zone BE, 2026-07-23.
